### PR TITLE
added jupyter notebook .ipynb_checkpoints to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # python files
 *.pyc
 
+# Jupyter Notebook
+.ipynb_checkpoints
+
 .idea/
 
 # virtual env


### PR DESCRIPTION
updated the .gitignore file to add the default option to ignore Jupyter notebook checkpoint files.